### PR TITLE
increase captureLength precision

### DIFF
--- a/jquery.typewatch.js
+++ b/jquery.typewatch.js
@@ -24,9 +24,9 @@
 		function checkElement(timer, override) {
 			var elTxt = jQuery(timer.el).val();
 
-			// Fire if text > options.captureLength AND text != saved txt OR if override AND text > options.captureLength
-			if ((elTxt.length > options.captureLength && elTxt.toUpperCase() != timer.text)
-			|| (override && elTxt.length > options.captureLength)) {
+			// Fire if text >= options.captureLength AND text != saved txt OR if override AND text >= options.captureLength
+			if ((elTxt.length >= options.captureLength && elTxt.toUpperCase() != timer.text)
+			|| (override && elTxt.length >= options.captureLength)) {
 				timer.text = elTxt.toUpperCase();
 				timer.cb(elTxt);
 			}


### PR DESCRIPTION
IMHO this increases the utility of `captureLength`. The current version is somewhat confusing because you need to set it to one more than the minimum number of characters you want to require. Additionally, the current version doesn't enable you to handle situations where a field is optional and has been set to '' i.e. a `captureLength` of 0 with this fork.
