### PR TITLE
Allows alternative when field capute length is not reached.

### DIFF
--- a/jquery.typewatch.js
+++ b/jquery.typewatch.js
@@ -22,6 +22,7 @@
 		var options = jQuery.extend({
 			wait: 750,
 			callback: function() { },
+			elsedo: function() { },
 			highlight: true,
 			captureLength: 2,
 			inputTypes: _supportedInputTypes
@@ -36,6 +37,9 @@
 			{
 				timer.text = value.toUpperCase();
 				timer.cb.call(timer.el, value);
+			} else {
+				timer.text = value.toUpperCase();
+				timer.ed.call(timer.el, value);
 			}
 		};
 
@@ -48,6 +52,7 @@
 					timer: null,
 					text: jQuery(elem).val().toUpperCase(),
 					cb: options.callback,
+					ed: options.elsedo,
 					el: elem,
 					wait: options.wait
 				};


### PR DESCRIPTION
Very simple enhancement to allow one to do an alternative like remove an ok tick if the field is below the capture length. One does not want to want to show a certain field as eg. "correct" when the field was not even checked. So this will allow you to call "elsedo" and cleanup say a graphical ok tick to show field is ok.