### PR TITLE
Update jquery.typewatch.js

### DIFF
--- a/jquery.typewatch.js
+++ b/jquery.typewatch.js
@@ -81,7 +81,7 @@
 					timer.timer = setTimeout(timerCallbackFx, timerWait);
 				};
 
-				jQuery(elem).keydown(startWatch);
+				jQuery(elem).on('keydown input', startWatch);
 			}
 		};
 


### PR DESCRIPTION
There is a known browser bug that if the user selects a string from the input fields history (the dropdown values that appears from previous entries) the element will not call startWatch().
