### PR TITLE
allow option for not submitting when pressing enter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,13 +20,14 @@ var options = {
     callback: function (value) { alert('TypeWatch callback: (' + this.type + ') ' + value); },
     wait: 750,
     highlight: true,
-    captureLength: 2
+    captureLength: 2,
+    submitOnEnter: true
 }
 
 $("#search").typeWatch( options );
 ```
 
-When working with any element other than __TEXTAREA__ pressing the __ENTER__ key will fire the callback function.
+When working with any element other than __TEXTAREA__ pressing the __ENTER__ key will fire the callback function unless the submitOnEnter option is set to false.
 
 Works with multiple elements:
 

--- a/jquery.typewatch.js
+++ b/jquery.typewatch.js
@@ -24,7 +24,8 @@
 			callback: function() { },
 			highlight: true,
 			captureLength: 2,
-			inputTypes: _supportedInputTypes
+			inputTypes: _supportedInputTypes,
+      submitOnEnter: false
 		}, o);
 
 		function checkElement(timer, override) {
@@ -66,8 +67,8 @@
 					var overrideBool = false;
 					var evtElementType = this.type.toUpperCase();
 
-					// If enter key is pressed and not a TEXTAREA and matched inputTypes
-					if (typeof evt.keyCode != 'undefined' && evt.keyCode == 13 && evtElementType != 'TEXTAREA' && jQuery.inArray(evtElementType, options.inputTypes) >= 0) {
+					// If enter key is pressed and not a TEXTAREA and matched inputTypes and submitOnEnter is true
+					if (options.submitOnEnter && typeof evt.keyCode != 'undefined' && evt.keyCode == 13 && evtElementType != 'TEXTAREA' && jQuery.inArray(evtElementType, options.inputTypes) >= 0) {
 						timerWait = 1;
 						overrideBool = true;
 					}
@@ -91,4 +92,3 @@
 		});
 
 	};
-})(jQuery);


### PR DESCRIPTION
Use case is I have a view similar to the iPhone Spotlight search screen. When I press the "search" button on the keyboard I don't want it to perform another search, I just want it to close and show the current results (which are updated continuously thanks to typewatch!)