### PR TITLE
Fire optional jQuery Event

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,12 +15,14 @@ Example:
 // wait: The number of milliseconds to wait after the the last key press before firing the callback
 // highlight: Highlights the element when it receives focus
 // captureLength: Minimum # of characters necessary to fire the callback
+// event: Optional name of a jQuery event that will be fired at the same time as the callback
 
 var options = {
     callback: function (value) { alert('TypeWatch callback: (' + this.type + ') ' + value); },
     wait: 750,
     highlight: true,
-    captureLength: 2
+    captureLength: 2,
+    event: 'typingDone'
 }
 
 $("#search").typeWatch( options );
@@ -34,6 +36,17 @@ Works with multiple elements:
 $(".textbox").typeWatch( options );
 ```
 
+You can also have typeWatch fire an event when typing is finished, by specifying the `event` option
+```javascript
+var options = {
+	event: 'typingDone'
+}
+$("input").typeWatch(options)
+
+$("input.name").on('typingDone', function(evt){
+	// Do something
+});
+```
 Lastly, if you use or enjoy TypeWatch beer donations are always appreciated
 
 [Donate a beer, half a beer, or a 6-pack](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=95YL35K45G4VA&lc=US&item_name=Denny+Ferrassoli&currency_code=USD&bn=PP-DonationsBF%3Abtn_donate_SM.gif%3ANonHosted)

--- a/jquery.typewatch.js
+++ b/jquery.typewatch.js
@@ -33,7 +33,8 @@
 			callback: function() { },
 			highlight: true,
 			captureLength: 2,
-			inputTypes: _supportedInputTypes
+			inputTypes: _supportedInputTypes,
+			event: false
 		}, o);
 
 		function checkElement(timer, override) {
@@ -45,6 +46,8 @@
 			{
 				timer.text = value.toUpperCase();
 				timer.cb.call(timer.el, value);
+				if( options.event )
+					$(timer.el).trigger( options.event )
 			}
 		};
 

--- a/test/index.html
+++ b/test/index.html
@@ -68,7 +68,12 @@
 				captureLength: 2,
 				callback: function(value) {
 					alert('TypeWatch callback: (' + this.type + ') ' + value);
-				}
+				},
+				event: 'finishedTyping'
+			});
+
+			$('input').on('finishedTyping', function(evt){
+				alert('TypeWatch event on '+evt.target);
 			});
 		});
 	</script>


### PR DESCRIPTION
I wanted to use your plugin to fire an event, so I went ahead and forked it and modded it. 

Basically, now there's an optional `event` option, which takes a string. If it's present, the library will trigger that string on the specific jQuery element, calling any handlers you have for that. For example:

``` javascript
$('input').typeWatch({
    event: 'typewatchEvent'
})

$('input.name').on('typewatchEvent', function(evt{
    console.log("Do something here");
});
```

Feel free to ask me if you have any questions or concerns about merging this!