### PR TITLE
Allow Submit (enter) without length limitation

### DIFF
--- a/jquery.typewatch.js
+++ b/jquery.typewatch.js
@@ -33,6 +33,7 @@
 			callback: function() { },
 			highlight: true,
 			captureLength: 2,
+			allowSubmit: false,
 			inputTypes: _supportedInputTypes
 		}, o);
 
@@ -41,7 +42,7 @@
 
 			// Fire if text >= options.captureLength AND text != saved text OR if override AND text >= options.captureLength
 			if ((value.length >= options.captureLength && value.toUpperCase() != timer.text)
-				|| (override && value.length >= options.captureLength))
+				|| (override && (value.length >= options.captureLength||options.allowSubmit))
 			{
 				timer.text = value.toUpperCase();
 				timer.cb.call(timer.el, value);


### PR DESCRIPTION
Allow user to submit without meeting the minimum text length (e.g. press enter when input box is empty to get top results)