### PR TITLE
Use click method instead of focus. This will work on WebKit browsers too.

### DIFF
--- a/jquery.typewatch.js
+++ b/jquery.typewatch.js
@@ -63,7 +63,7 @@
 
 				// Set focus action (highlight)
 				if (options.highlight) {
-					$(elem).focus(
+					$(elem).click(
 						function() {
 							this.select();
 						});


### PR DESCRIPTION
In WebKit browsers,
```
$(this).focus(
  function() {
    $(this).select();
  }
);
```
the above snippet won't work.
It has to be `click` method instead of `focus` method.

http://stackoverflow.com/questions/480735/select-all-contents-of-textbox-when-it-receives-focus-javascript-or-jquery#comment27680389_480754