### PR TITLE
Remove explicit bower version (deprecated option)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "jquery-typewatch",
-  "version": "3.0.0",
   "main": [
     "./jquery.typewatch.js"
   ],


### PR DESCRIPTION
`version` option is deprecated and ignored by Bower, as noticed in  [JSON spec](https://github.com/bower/spec/blob/master/json.md#version):

>`Deprecated`. Use git or svn tags instead. This field is ignored by Bower.