### PR TITLE
Fix problem when using typewatch with JSF and AJAX

### DIFF
--- a/jquery.typewatch.js
+++ b/jquery.typewatch.js
@@ -92,7 +92,7 @@
 					timer.timer = setTimeout(timerCallbackFx, timerWait);
 				};
 
-				jQuery(elem).on('keydown paste cut input', startWatch);
+                jQuery(elem).bind('keydown.typewatch paste.typewatch cut.typewatch input.typewatch',startWatch);
 			}
 		};
 


### PR DESCRIPTION
In JSF, when AJAX is called, the jquery-plugins need to be restarted everytime (using jsf.ajax.addOnEvent) and it cause problem in typewatch plugin, because events (keydown, paste,cut and input) are called multiple times. So, if this event hit a database, the database is called multiple times causing a lot of problems (poor performance application). 

To solve it, i added a name for each event (keydown.typewatch, paste.typewatch ...), and you can unbind just this event to restart typewatch, like this code:


```
$(document).ready(function () {
jsf.ajax.addOnEvent(restartTypewatch);
});

function restartTypewatch(){
//unbind all events to avoid multiple calls
$('#my-input-text').unbind('keydown.typewatch paste.typewatch cut.typewatch input.typewatch');

//start typeWatch again
$('#my-input-text').typeWatch(options);
}

```


You can't unbind all "keydown" events because it will cause problems in another jquery-plugins, like this:

```

//unbind all keydown in this component can cause problem in others plugins, better unbind just typewatch
$('#my-input-text').unbind('keydown');

```